### PR TITLE
Adds ake.Server Serde methods

### DIFF
--- a/internal/ake/server.go
+++ b/internal/ake/server.go
@@ -21,6 +21,8 @@ import (
 	"github.com/bytemare/opaque/message"
 )
 
+var errAkeStateNotEmpty = errors.New("existing state is not empty")
+
 // Server exposes the server's AKE functions and holds its state.
 type Server struct {
 	clientMac     []byte
@@ -89,14 +91,15 @@ func (s *Server) SerializeState() []byte {
 }
 
 // SetState will set the given clientMac and sessionSecret in the server's
-// internal state
+// internal state.
 func (s *Server) SetState(clientMac, sessionSecret []byte) error {
 	if len(s.clientMac) != 0 || len(s.sessionSecret) != 0 {
-		return errors.New("existing state is not empty")
+		return errAkeStateNotEmpty
 	}
 
 	s.clientMac = clientMac
 	s.sessionSecret = sessionSecret
+
 	return nil
 }
 

--- a/internal/ake/server.go
+++ b/internal/ake/server.go
@@ -21,7 +21,7 @@ import (
 	"github.com/bytemare/opaque/message"
 )
 
-var errAkeStateNotEmpty = errors.New("existing state is not empty")
+var errStateNotEmpty = errors.New("existing state is not empty")
 
 // Server exposes the server's AKE functions and holds its state.
 type Server struct {
@@ -79,8 +79,7 @@ func (s *Server) Response(p *internal.Parameters, serverIdentity []byte, serverS
 	return ke2, nil
 }
 
-// SerializeState will return a []byte with the given capacity containing
-// internal state of the Server.
+// SerializeState will return a []byte containing internal state of the Server.
 func (s *Server) SerializeState() []byte {
 	state := make([]byte, len(s.clientMac)+len(s.sessionSecret))
 
@@ -90,11 +89,10 @@ func (s *Server) SerializeState() []byte {
 	return state
 }
 
-// SetState will set the given clientMac and sessionSecret in the server's
-// internal state.
+// SetState will set the given clientMac and sessionSecret in the server's internal state.
 func (s *Server) SetState(clientMac, sessionSecret []byte) error {
 	if len(s.clientMac) != 0 || len(s.sessionSecret) != 0 {
-		return errAkeStateNotEmpty
+		return errStateNotEmpty
 	}
 
 	s.clientMac = clientMac

--- a/server.go
+++ b/server.go
@@ -185,8 +185,7 @@ func (s *Server) DeserializeKE3(ke3 []byte) (*message.KE3, error) {
 // DeserializeAKEState sets the interal state of the AKE server from the given
 // bytes
 func (s *Server) DeserializeAKEState(state []byte) error {
-	l := s.Parameters.MAC.Size()
-	if len(state) != 2*l {
+	if len(state) != s.MAC.Size() + s.KDF.Size() {
 		return errors.New("state is the wrong length")
 	}
 

--- a/server.go
+++ b/server.go
@@ -20,8 +20,13 @@ import (
 	"github.com/bytemare/opaque/message"
 )
 
-// ErrAkeInvalidClientMac indicates that the MAC contained in the KE3 message is not valid in the given session.
-var ErrAkeInvalidClientMac = errors.New("failed to authenticate client: invalid client mac")
+var (
+	// ErrAkeInvalidClientMac indicates that the MAC contained in the KE3 message is not valid in the given session.
+	ErrAkeInvalidClientMac = errors.New("failed to authenticate client: invalid client mac")
+
+	// ErrInvalidState indicates that the given state is not valid due to a wrong length.
+	ErrInvalidState = errors.New("invalid state length")
+)
 
 // Server represents an OPAQUE Server, exposing its functions and holding its state.
 type Server struct {
@@ -182,17 +187,16 @@ func (s *Server) DeserializeKE3(ke3 []byte) (*message.KE3, error) {
 	return s.Parameters.DeserializeKE3(ke3)
 }
 
-// SetAKEState sets the interal state of the AKE server from the given bytes
+// SetAKEState sets the internal state of the AKE server from the given bytes.
 func (s *Server) SetAKEState(state []byte) error {
 	if len(state) != s.MAC.Size()+s.KDF.Size() {
-		return errors.New("invalid state length")
+		return ErrInvalidState
 	}
 
 	return s.Ake.SetState(state[:s.MAC.Size()], state[s.MAC.Size():])
 }
 
-// SerializeState returns the internal state of the AKE server serialized to
-// bytes
+// SerializeState returns the internal state of the AKE server serialized to bytes.
 func (s *Server) SerializeState() []byte {
 	return s.Ake.SerializeState()
 }

--- a/server.go
+++ b/server.go
@@ -182,14 +182,13 @@ func (s *Server) DeserializeKE3(ke3 []byte) (*message.KE3, error) {
 	return s.Parameters.DeserializeKE3(ke3)
 }
 
-// DeserializeAKEState sets the interal state of the AKE server from the given
-// bytes
-func (s *Server) DeserializeAKEState(state []byte) error {
-	if len(state) != s.MAC.Size() + s.KDF.Size() {
-		return errors.New("state is the wrong length")
+// SetAKEState sets the interal state of the AKE server from the given bytes
+func (s *Server) SetAKEState(state []byte) error {
+	if len(state) != s.MAC.Size()+s.KDF.Size() {
+		return errors.New("invalid state length")
 	}
 
-	return s.Ake.SetState(state[:l], state[l:])
+	return s.Ake.SetState(state[:s.MAC.Size()], state[s.MAC.Size():])
 }
 
 // SerializeState returns the internal state of the AKE server serialized to

--- a/server.go
+++ b/server.go
@@ -142,10 +142,14 @@ func (s *Server) Finish(ke3 *message.KE3) error {
 	return nil
 }
 
-// SessionKey returns the session key if the previous calls to Init() and Finish() were
-// successful.
+// SessionKey returns the session key if the previous call to Init() was successful.
 func (s *Server) SessionKey() []byte {
 	return s.Ake.SessionKey()
+}
+
+// ExpectedMAC returns the expected client MAC if the previous call to Init() was successful.
+func (s *Server) ExpectedMAC() []byte {
+	return s.Ake.ExpectedMAC()
 }
 
 // DeserializeRegistrationRequest takes a serialized RegistrationRequest message and returns a deserialized RegistrationRequest structure.
@@ -176,4 +180,21 @@ func (s *Server) DeserializeKE2(ke2 []byte) (*message.KE2, error) {
 // DeserializeKE3 takes a serialized KE3 message and returns a deserialized KE3 structure.
 func (s *Server) DeserializeKE3(ke3 []byte) (*message.KE3, error) {
 	return s.Parameters.DeserializeKE3(ke3)
+}
+
+// DeserializeAKEState sets the interal state of the AKE server from the given
+// bytes
+func (s *Server) DeserializeAKEState(state []byte) error {
+	l := s.Parameters.MAC.Size()
+	if len(state) != 2*l {
+		return errors.New("state is the wrong length")
+	}
+
+	return s.Ake.SetState(state[:l], state[l:])
+}
+
+// SerializeState returns the internal state of the AKE server serialized to
+// bytes
+func (s *Server) SerializeState() []byte {
+	return s.Ake.SerializeState()
 }

--- a/tests/failing_test.go
+++ b/tests/failing_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 var errInvalidMessageLength = errors.New("invalid message length")
+var errInvalidStateLength = errors.New("invalid state length")
 
 func TestDeserializeRegistrationRequest(t *testing.T) {
 	c := opaque.DefaultConfiguration()
@@ -124,6 +125,19 @@ func TestDeserializeKE3(t *testing.T) {
 	client := c.Client()
 	if _, err := client.DeserializeKE3(internal.RandomBytes(ke3Length + 1)); err == nil || err.Error() != errInvalidMessageLength.Error() {
 		t.Fatalf("Expected error for DeserializeKE1. want %q, got %q", errInvalidMessageLength, err)
+	}
+}
+
+func TestSetAKEState(t *testing.T) {
+	c := opaque.DefaultConfiguration()
+	macLength := c.MAC.Size()
+	keyLength := c.KDF.Size()
+
+	buf := internal.RandomBytes(macLength + keyLength + 1)
+
+	server := c.Server()
+	if err := server.SetAKEState(buf); err == nil || err.Error() != errInvalidStateLength.Error() {
+		t.Fatalf("Expected error for SetAKEState. want %q, got %q", errInvalidStateLength, err)
 	}
 }
 

--- a/tests/opaque_test.go
+++ b/tests/opaque_test.go
@@ -150,10 +150,9 @@ func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord
 	}
 
 	// Server
-	server := p.Server()
-
 	var m5s []byte
 	{
+		server := p.Server()
 		m4, err := server.DeserializeKE1(m4s)
 		if err != nil {
 			t.Fatalf(dbgErr, p.Mode, err)
@@ -190,6 +189,7 @@ func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord
 	// Server
 	var serverKey []byte
 	{
+		server := p.Server()
 		m6, err := server.DeserializeKE3(m6s)
 		if err != nil {
 			t.Fatalf(dbgErr, p.Mode, err)

--- a/tests/opaque_test.go
+++ b/tests/opaque_test.go
@@ -198,7 +198,7 @@ func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 
-		if err := server.DeserializeAKEState(state); err != nil {
+		if err := server.SetAKEState(state); err != nil {
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 

--- a/tests/opaque_test.go
+++ b/tests/opaque_test.go
@@ -69,106 +69,138 @@ func TestFull(t *testing.T) {
 func testRegistration(t *testing.T, p *testParams) (*opaque.ClientRecord, []byte) {
 	// Client
 	client := p.Client()
-	reqReg := client.RegistrationInit(p.password)
-	m1s := reqReg.Serialize()
+
+	var m1s []byte
+	{
+		reqReg := client.RegistrationInit(p.password)
+		m1s = reqReg.Serialize()
+	}
 
 	// Server
 	server := p.Server()
-	m1, err := server.DeserializeRegistrationRequest(m1s)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
 
-	credID := internal.RandomBytes(32)
-	respReg, err := server.RegistrationResponse(m1, p.serverPublicKey, credID, p.oprfSeed)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+	var m2s []byte
+	var credID []byte
+	{
+		m1, err := server.DeserializeRegistrationRequest(m1s)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	m2s := respReg.Serialize()
+		credID = internal.RandomBytes(32)
+		respReg, err := server.RegistrationResponse(m1, p.serverPublicKey, credID, p.oprfSeed)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
+
+		m2s = respReg.Serialize()
+	}
 
 	// Client
-	clientCreds := &opaque.Credentials{
-		Client: p.username,
-		Server: p.serverID,
-	}
+	var m3s []byte
+	var exportKeyReg []byte
+	{
+		clientCreds := &opaque.Credentials{
+			Client: p.username,
+			Server: p.serverID,
+		}
 
-	var clientSecretKey []byte
-	if p.Mode == opaque.External {
-		clientSecretKey, _ = client.KeyGen()
-	}
+		var clientSecretKey []byte
+		if p.Mode == opaque.External {
+			clientSecretKey, _ = client.KeyGen()
+		}
 
-	m2, err := client.DeserializeRegistrationResponse(m2s)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+		m2, err := client.DeserializeRegistrationResponse(m2s)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	upload, exportKeyReg, err := client.RegistrationFinalize(clientSecretKey, clientCreds, m2)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+		upload, key, err := client.RegistrationFinalize(clientSecretKey, clientCreds, m2)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
+		exportKeyReg = key
 
-	m3s := upload.Serialize()
+		m3s = upload.Serialize()
+	}
 
 	// Server
-	m3, err := server.DeserializeRegistrationUpload(m3s)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+	{
+		m3, err := server.DeserializeRegistrationUpload(m3s)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	return &opaque.ClientRecord{
-		CredentialIdentifier: credID,
-		ClientIdentity:       p.username,
-		RegistrationUpload:   m3,
-	}, exportKeyReg
+		return &opaque.ClientRecord{
+			CredentialIdentifier: credID,
+			ClientIdentity:       p.username,
+			RegistrationUpload:   m3,
+		}, exportKeyReg
+	}
 }
 
 func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord) []byte {
 	// Client
 	client := p.Client()
-	ke1 := client.Init(p.password)
-	m4s := ke1.Serialize()
+
+	var m4s []byte
+	{
+		ke1 := client.Init(p.password)
+		m4s = ke1.Serialize()
+	}
 
 	// Server
 	server := p.Server()
 
-	m4, err := server.DeserializeKE1(m4s)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+	var m5s []byte
+	{
+		m4, err := server.DeserializeKE1(m4s)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	ke2, err := server.Init(m4, p.serverID, p.serverSecretKey, p.serverPublicKey, p.oprfSeed, record)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+		ke2, err := server.Init(m4, p.serverID, p.serverSecretKey, p.serverPublicKey, p.oprfSeed, record)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	m5s := ke2.Serialize()
+		m5s = ke2.Serialize()
+	}
 
 	// Client
-	m5, err := client.DeserializeKE2(m5s)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+	var m6s []byte
+	var exportKeyLogin []byte
+	var clientKey []byte
+	{
+		m5, err := client.DeserializeKE2(m5s)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	ke3, exportKeyLogin, err := client.Finish(p.username, p.serverID, m5)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+		ke3, key, err := client.Finish(p.username, p.serverID, m5)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
+		exportKeyLogin = key
 
-	m6s := ke3.Serialize()
+		m6s = ke3.Serialize()
+		clientKey = client.SessionKey()
+	}
 
 	// Server
-	m6, err := server.DeserializeKE3(m6s)
-	if err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+	var serverKey []byte
+	{
+		m6, err := server.DeserializeKE3(m6s)
+		if err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	if err := server.Finish(m6); err != nil {
-		t.Fatalf(dbgErr, p.Mode, err)
-	}
+		if err := server.Finish(m6); err != nil {
+			t.Fatalf(dbgErr, p.Mode, err)
+		}
 
-	clientKey := client.SessionKey()
-	serverKey := server.SessionKey()
+		serverKey = server.SessionKey()
+	}
 
 	if !bytes.Equal(clientKey, serverKey) {
 		t.Fatalf("mode %v: session keys differ", p.Mode)

--- a/tests/opaque_test.go
+++ b/tests/opaque_test.go
@@ -168,7 +168,7 @@ func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 
-		state = serializeAkeServerState(server.Ake)
+		state = server.Ake.SerializeState(server.MAC.Size())
 
 		m5s = ke2.Serialize()
 	}
@@ -202,7 +202,7 @@ func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 
-		if err := deserializeAkeServerState(state, server.Ake); err != nil {
+		if err := server.Ake.DeserializeState(state, server.MAC.Size()); err != nil {
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 

--- a/tests/opaque_test.go
+++ b/tests/opaque_test.go
@@ -168,7 +168,7 @@ func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 
-		state = server.Ake.SerializeState(server.MAC.Size())
+		state = server.SerializeState()
 
 		m5s = ke2.Serialize()
 	}
@@ -202,7 +202,7 @@ func testAuthentication(t *testing.T, p *testParams, record *opaque.ClientRecord
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 
-		if err := server.Ake.DeserializeState(state, server.MAC.Size()); err != nil {
+		if err := server.DeserializeAKEState(state); err != nil {
 			t.Fatalf(dbgErr, p.Mode, err)
 		}
 

--- a/tests/opaque_test.go
+++ b/tests/opaque_test.go
@@ -77,11 +77,10 @@ func testRegistration(t *testing.T, p *testParams) (*opaque.ClientRecord, []byte
 	}
 
 	// Server
-	server := p.Server()
-
 	var m2s []byte
 	var credID []byte
 	{
+		server := p.Server()
 		m1, err := server.DeserializeRegistrationRequest(m1s)
 		if err != nil {
 			t.Fatalf(dbgErr, p.Mode, err)
@@ -126,6 +125,7 @@ func testRegistration(t *testing.T, p *testParams) (*opaque.ClientRecord, []byte
 
 	// Server
 	{
+		server := p.Server()
 		m3, err := server.DeserializeRegistrationUpload(m3s)
 		if err != nil {
 			t.Fatalf(dbgErr, p.Mode, err)


### PR DESCRIPTION
This is an implementation of the request in https://github.com/bytemare/opaque/discussions/7. Please refer to that discussion for background.

Changes in `tests/opaque_test.go` are from the discussion and are not meant to make any material change to the test.

The focus of this PR is adding two new methods to `ake.Server`:

```go
// SerializeState will return a []byte with the given capacity containing
// internal state of the Server.
func (s *Server) SerializeState(size int) []byte
```

```go
// DeserializeState will set internal state onto the server. `size` should the
// output of internal.Parameters.MAC.Size()
func (s *Server) DeserializeState(data []byte, size int) error
```

Example usage from the modified test:

```go
// serialize the state to be persisted elsewhere
state = server.Ake.SerializeState(server.MAC.Size())
```

```go
// retrieve serialized state and deserialize onto server
err := server.Ake.DeserializeState(state, server.MAC.Size())
```