### PR TITLE
fix superflous space and make error lowercased

### DIFF
--- a/internal/ake/client.go
+++ b/internal/ake/client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/bytemare/opaque/message"
 )
 
-var errAkeInvalidServerMac = errors.New(" AKE finalization: invalid server mac")
+var ErrInvalidServerMac = errors.New("ake finalization: invalid server mac")
 
 // Client exposes the client's AKE functions and holds its state.
 type Client struct {
@@ -72,7 +72,7 @@ func (c *Client) Finalize(
 	sessionSecret, serverMac, clientMac := core3DH(conf, ikm, clientIdentity, serverIdentity, c.Ke1, ke2)
 
 	if !conf.MAC.Equal(serverMac, ke2.Mac) {
-		return nil, errAkeInvalidServerMac
+		return nil, ErrInvalidServerMac
 	}
 
 	c.sessionSecret = sessionSecret

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -9,6 +9,8 @@
 package opaque_test
 
 import (
+	"errors"
+	"github.com/bytemare/opaque/internal/ake"
 	"strings"
 	"testing"
 
@@ -257,8 +259,10 @@ func TestClientFinish_InvalidKE2Mac(t *testing.T) {
 		ke2, _ := server.LoginInit(ke1, nil, sks, pks, oprfSeed, rec)
 
 		ke2.Mac = internal.RandomBytes(client.GetConf().MAC.Size())
-		expected := " AKE finalization: invalid server mac"
-		if _, _, err := client.LoginFinish(nil, nil, ke2); err == nil || !strings.HasPrefix(err.Error(), expected) {
+
+		_, _, err := client.LoginFinish(nil, nil, ke2)
+
+		if !errors.Is(err, ake.ErrInvalidServerMac) {
 			t.Fatalf("expected error for invalid epks encoding - got %q", err)
 		}
 	}


### PR DESCRIPTION
Hi there,

this PR removes a superflous space and makes the start of the sentence lowercased.