### PR TITLE
Use RandomBytes for fake record envelope; reject trailing bytes in DeserializeConfiguration

### DIFF
--- a/opaque.go
+++ b/opaque.go
@@ -185,9 +185,13 @@ func DeserializeConfiguration(encoded []byte) (*Configuration, error) {
 		return nil, ErrConfiguration.Join(internal.ErrInvalidEncodingLength)
 	}
 
-	ctx, _, err := encoding.DecodeVector(encoded[confIDsLength:])
+	ctx, offset, err := encoding.DecodeVector(encoded[confIDsLength:])
 	if err != nil {
 		return nil, ErrConfiguration.Join(internal.ErrInvalidContextEncoding, err)
+	}
+
+	if confIDsLength+offset != len(encoded) {
+		return nil, ErrConfiguration.Join(internal.ErrInvalidEncodingLength)
 	}
 
 	c := &Configuration{
@@ -221,7 +225,7 @@ func (c *Configuration) GetFakeRecord(credentialIdentifier []byte) (*ClientRecor
 	regRecord := &message.RegistrationRecord{
 		ClientPublicKey: publicKey,
 		MaskingKey:      RandomBytes(conf.Sizes.Hash),
-		Envelope:        make([]byte, conf.Sizes.Envelope),
+		Envelope:        RandomBytes(conf.Sizes.Envelope),
 	}
 
 	return &ClientRecord{

--- a/tests/opaque_test.go
+++ b/tests/opaque_test.go
@@ -489,6 +489,36 @@ func TestDeserializeConfiguration_Short(t *testing.T) {
 	}, opaque.ErrConfiguration, internal.ErrInvalidEncodingLength)
 }
 
+// TestDeserializeConfiguration_TrailingBytes verifies that trailing bytes after the context vector are rejected.
+// This matches the strict parsing already used in DecodeServerKeyMaterial.
+func TestDeserializeConfiguration_TrailingBytes(t *testing.T) {
+	// Empty context: trailing bytes after the 2-byte zero-length header.
+	canonical := opaque.DefaultConfiguration().Serialize()
+	expectErrors(t, func() error {
+		_, err := opaque.DeserializeConfiguration(append(canonical, 0xDE, 0xAD))
+		return err
+	}, opaque.ErrConfiguration, internal.ErrInvalidEncodingLength)
+
+	// Non-empty context: exercises the case where the decoded offset > 2.
+	conf := opaque.DefaultConfiguration()
+	conf.Context = []byte("test-context")
+	encoded := conf.Serialize()
+
+	decoded, err := opaque.DeserializeConfiguration(encoded)
+	if err != nil {
+		t.Fatalf("round-trip with context failed: %v", err)
+	}
+
+	if err = conf.Equals(decoded); err != nil {
+		t.Fatalf("round-trip with context produced different config: %v", err)
+	}
+
+	expectErrors(t, func() error {
+		_, err := opaque.DeserializeConfiguration(append(encoded, 0xFF))
+		return err
+	}, opaque.ErrConfiguration, internal.ErrInvalidEncodingLength)
+}
+
 // TestBadConfiguration enumerates invalid algorithm identifiers to ensure misconfigured deployments fail during setup instead of misbehaving later.
 func TestBadConfiguration(t *testing.T) {
 	setBadValue := func(pos, val int) []byte {
@@ -615,12 +645,23 @@ func TestConfiguration_MixedGroups(t *testing.T) {
 	}
 }
 
-// TestGetFakeRecord ensures GetFakeRecord succeeds for valid configurations and rejects invalid ones.
+// TestGetFakeRecord ensures GetFakeRecord succeeds for valid configurations, rejects invalid ones,
+// and produces envelopes that are not trivially distinguishable from real registration envelopes.
 func TestGetFakeRecord(t *testing.T) {
 	// Test valid configurations
 	testAll(t, func(t *testing.T, conf *configuration) {
-		if _, err := conf.conf.GetFakeRecord(nil); err != nil {
+		record, err := conf.conf.GetFakeRecord(nil)
+		if err != nil {
 			t.Fatalf("unexpected error on valid configuration: %v", err)
+		}
+
+		// The envelope must contain random bytes rather than zero-fill.
+		// Real envelopes hold a random nonce + MAC tag, so an all-zero
+		// envelope would be trivially distinguishable at rest.
+		env := record.RegistrationRecord.Envelope
+		allZeros := make([]byte, len(env))
+		if bytes.Equal(env, allZeros) {
+			t.Error("fake record envelope is all zeros")
 		}
 	})
 

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -101,6 +101,37 @@ func TestServerInit_InvalidOPRFSeedLength(t *testing.T) {
 	})
 }
 
+// TestGenerateKE2_FakeRecord ensures fake records produce valid KE2 responses across all suites.
+func TestGenerateKE2_FakeRecord(t *testing.T) {
+	testAll(t, func(t *testing.T, conf *configuration) {
+		client, server := setup(t, conf)
+
+		fakeRecord, err := conf.conf.GetFakeRecord([]byte("fake-id"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ke1, err := client.GenerateKE1(password)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ke2, _, err := server.GenerateKE2(ke1, fakeRecord)
+		if err != nil {
+			t.Fatalf("GenerateKE2 with fake record failed: %v", err)
+		}
+
+		if ke2 == nil {
+			t.Fatal("GenerateKE2 returned nil KE2")
+		}
+
+		if len(ke2.Serialize()) != conf.internal.Sizes.KE2 {
+			t.Fatalf("KE2 size mismatch: got %d, want %d",
+				len(ke2.Serialize()), conf.internal.Sizes.KE2)
+		}
+	})
+}
+
 // TestNewServer_DefaultConfiguration confirms that spinning up a server with nil configuration yields a working setup, exercising the end-to-end happy path for the default suite.
 func TestNewServer_DefaultConfiguration(t *testing.T) {
 	server, err := opaque.NewServer(nil)


### PR DESCRIPTION
`GetFakeRecord` uses `make([]byte, conf.Sizes.Envelope)` for the envelope, producing all zeros. Real envelopes contain a random nonce + MAC tag, so fake records are distinguishable at rest. The fix is the same `RandomBytes` call already used for `MaskingKey` on the line above.

Separately, `DeserializeConfiguration` discards the offset from `DecodeVector` (`_`), silently accepting trailing bytes. `DecodeServerKeyMaterial` in `skm.go` already checks this; this brings the config parser in line.

Neither change affects on-wire behavior (the masking key is random, so the XOR output is indistinguishable either way).

## Tests

First commit adds tests, second commit adds fixes.

- `TestGetFakeRecord` extended -- envelope is not all-zero
- `TestDeserializeConfiguration_TrailingBytes` -- rejects trailing bytes with empty and non-empty context
- `TestGenerateKE2_FakeRecord` -- fake records still produce valid KE2
- Full existing suite passes